### PR TITLE
Modification de la visualisation des projets à capitaliser

### DIFF
--- a/project_accounting/models/project.py
+++ b/project_accounting/models/project.py
@@ -109,11 +109,16 @@ class projectAccountProject(models.Model):
                         raise ValidationError(_("Le montant HT piloté initial (sur l'onglet Structure au lancement) ne peut pas être nul pour passer au statut %s, hormis pour les clients pro bono." %(new_stage_id.name)))
                     if not(record.order_cost_initial) :
                         raise ValidationError(_("Le coût total initial (sur l'onglet Structure au lancement) ne peut pas être nul pour passer au statut %s." %(new_stage_id.name)))
-                if new_stage_id.id in [9, 3]: # nouveau statut est prod terminée
+                if new_stage_id.id in [9, 3]: # nouveau statut appartient à l'un des statuts [Prod terminée / Clos]
                     if not (record.deliverable_indexation) or not (record.sales_proposal_indexation) or not (
                     record.commercial_reference_indexation) or not (record.commercial_reference_indexation):
                         raise ValidationError(
                             _("Tous les attributs de l'onglet Capitalisation doivent être valorisés pour passer au statut %s" % (
+                                new_stage_id.name)))
+                if new_stage_id.id in [6, 2] : # nouveau statut appartient à l'un des statuts [Accord client / Commandé]
+                    if not (record.sales_proposal_indexation) :
+                        raise ValidationError(
+                            _("L'attribut Proposition commerciale dans l'onglet Capitalisation doit être valorisé pour passer au statut %s" % (
                                 new_stage_id.name)))
 
         return res
@@ -254,7 +259,7 @@ class projectAccountProject(models.Model):
                 is_closable = False
                 error_message += "   - L'attribut Proposition commerciale dans l'onglet Capitalisation n'est pas valorisé.\n"
 
-            if self.deliverable_indexation != False and self.deliverable_indexation != 'not_to_be_capitalized_without_anonymization':
+            if self.deliverable_indexation != False and self.deliverable_indexation != 'not_to_be_capitalized':
                 is_closable = False
                 error_message += "   - L'attribut Livrables dans l'onglet Capitalisation est valorisée. \n"
 

--- a/project_accounting/views/project.xml
+++ b/project_accounting/views/project.xml
@@ -37,7 +37,6 @@
                     <filter string="Archived" name="inactive" domain="[('active', '=', False)]"/>
 					<separator/>
 					<filter string="Projet avec au moins un élément à capitaliser" name="project_to_be_capitalized" domain="['|','|','|',('sales_proposal_indexation', 'in', ['to_be_capitalized']),('deliverable_indexation', 'in', ['to_be_capitalized_without_anonymization','to_be_capitalized_with_anonymization']),('success_story_indexation', 'in', ['yes_success_story']),('commercial_reference_indexation', 'in', ['yes_commercial_reference']),]"/>
-					<filter string="Projet avec propale capitalisée ou livrable capitalisé ou succes story réalisée ou référence validée" name="project_capitalized" domain="['|','|','|',('sales_proposal_indexation', 'in', ['capitalized']),('deliverable_indexation', 'in', ['capitalized']),('success_story_indexation', 'in', ['success_story_completed']),('commercial_reference_indexation', 'in', ['commercial_reference_validated']),]"/>
                     <group expand="0" string="Group By">
                         <filter string="Directeur de mission" name="Manager" context="{'group_by': 'project_director_employee_id'}"/>
                         <filter string="Client" name="Partner" context="{'group_by': 'partner_id'}"/>
@@ -86,6 +85,10 @@
 		  <field name="company_to_invoice_left" optional="hide" sum="Total"/>
 		  <field name="agreement_id" optional="hide"/>
 		  <field name="reporting_sum_company_outsource_code3_code_4" sum="Total" optional="show"/>
+		  <field name="sales_proposal_indexation" optional="hide"/>
+		  <field name="deliverable_indexation" optional="hide"/>
+		  <field name="success_story_indexation" optional="hide"/>
+		  <field name="commercial_reference_indexation" optional="hide"/>
 		</tree>
 	      </field>
 	    </record>


### PR DESCRIPTION
- suppression du filtre des projets "au moins un élément capitalisé"
- ajout des 4 champs cachés par défaut dans la vue "tree" des projets : proposition commerciale, livrable, success story, référence commerciale
- ajout d'un contrôle sur le champs **proposition commerciale** pour le passage en statut 3 ou 4. Les contrôles pour les statuts perdus ou après 4 étaient déjà présents