### PR TITLE
Travail sur les éléments de capitalisation projets

### DIFF
--- a/project_accounting/models/project.py
+++ b/project_accounting/models/project.py
@@ -255,22 +255,6 @@ class projectAccountProject(models.Model):
                 is_closable = False
                 error_message += "   - Il reste des provisions ou du stock sur la dernière clôture.\n"
 
-            if not self.sales_proposal_indexation :
-                is_closable = False
-                error_message += "   - L'attribut Proposition commerciale dans l'onglet Capitalisation n'est pas valorisé.\n"
-
-            if self.deliverable_indexation != False and self.deliverable_indexation != 'not_to_be_capitalized':
-                is_closable = False
-                error_message += "   - L'attribut Livrables dans l'onglet Capitalisation est valorisée. \n"
-
-            if self.success_story_indexation != False and self.success_story_indexation != 'no_success_story':
-                is_closable = False
-                error_message += "   - L'attribut Success story dans l'onglet Capitalisation est valorisé. \n"
-
-            if self.commercial_reference_indexation != False and self.commercial_reference_indexation != 'no_commercial_reference' :
-                is_closable = False
-                error_message += "   - L'attribut référence commerciale dans l'onglet Capitlisation est valorisé. \n"
-
         return is_closable, error_message
 
 
@@ -312,25 +296,29 @@ class projectAccountProject(models.Model):
     # Champs relatifs à la capitalisation des projets
     sales_proposal_indexation = fields.Selection([
         ('to_be_capitalized', 'À capitaliser'),
-        ('not_to_be_capitalized', 'À ne pas capitaliser'),
+        ('not_to_be_capitalized', 'Ne pas capitaliser'),
         ('capitalized', "Capitalisée"),
+        ('not_specified','Non renseigné'),
     ], string="Proposition commerciale")
     deliverable_indexation = fields.Selection([
         ('to_be_capitalized_without_anonymization', 'À capitaliser (sans anonymisation)'),
         ('to_be_capitalized_with_anonymization', 'À capitaliser (avec anonymisation)'),
-        ('not_to_be_capitalized', 'À ne pas capitaliser'),
+        ('not_to_be_capitalized', 'Ne pas capitaliser'),
         ('capitalized', "Capitalisé"),
+        ('not_specified','Non renseigné')
     ], string="Livrable")
     success_story_indexation = fields.Selection([
-        ('yes_success_story', 'Oui'),
-        ('no_success_story', 'Non'),
+        ('yes_success_story', 'À réaliser'),
+        ('no_success_story', 'Ne pas réaliser'),
         ('success_story_completed', 'Réalisée'),
+        ('not_specified', 'Non renseigné'),
     ], string="Success story")
     commercial_reference_indexation = fields.Selection([
-        ('yes_commercial_reference', 'Oui'),
-        ('no_commercial_reference', 'Non'),
+        ('yes_commercial_reference', 'Référence à créer'),
+        ('no_commercial_reference', 'Ne pas créer'),
         ('commercial_reference_created', 'Référence créée'),
         ('commercial_reference_validated', "Référence validée"),
+        ('not_specified', 'Non renseigné')
     ], string="Référence commerciale")
 
 
@@ -592,7 +580,27 @@ class projectAccountProject(models.Model):
             if 0.0 in reselling_subtotal_by_order_id.values():
                 is_outsource_part_amount_current = False
             rec.is_outsource_part_amount_current = is_outsource_part_amount_current
-            
+
+            is_filled_sales_proposal_indexation = True
+            if not(rec.sales_proposal_indexation) and rec.stage_id.id in [6, 2, 9, 3, 8]:
+                is_filled_sales_proposal_indexation = False
+            rec.is_filled_sales_proposal_indexation = is_filled_sales_proposal_indexation
+
+            is_filled_deliverable_indexation = True
+            if not (rec.deliverable_indexation) and rec.stage_id.id in [9, 3]:
+                is_filled_deliverable_indexation = False
+            rec.is_filled_deliverable_indexation = is_filled_deliverable_indexation
+
+            is_filled_commercial_reference_indexation = True
+            if not (rec.commercial_reference_indexation) and rec.stage_id.id in [9, 3]:
+                is_filled_commercial_reference_indexation = False
+            rec.is_filled_commercial_reference_indexation = is_filled_commercial_reference_indexation
+
+            is_filled_success_story_indexation = True
+            if not (rec.success_story_indexation) and rec.stage_id.id in [9, 3]:
+                is_filled_success_story_indexation = False
+            rec.is_filled_success_story_indexation = is_filled_success_story_indexation
+
 
             if rec.other_part_marging_rate_current >= float(self.env['ir.config_parameter'].sudo().get_param("other_part_marging_rate_alert_level")):
                 rec.other_part_marging_rate_controle_OK = True
@@ -1313,3 +1321,9 @@ class projectAccountProject(models.Model):
     reporting_company_part_amount_current_at_least_code_4 = fields.Float('CA interne commandé si code 4/5/6 sinon 0', compute=compute_reporting_shortcuts, store=True)
     reporting_sum_company_outsource_code3_code_4 = fields.Float('Prise de commande', help='Somme CA interne + markup commandé code 3/4/5/6', compute=compute_reporting_shortcuts, store=True)
     #purchase_line_ids = fields.One2many('purchase.order.line', 'rel_project_ids')
+
+    # CAPITALIZATION
+    is_filled_sales_proposal_indexation = fields.Boolean("Champ Proposition commerciale valorisé", store=True, compute=compute, help="FAUX si le champ Proposition commerciale dans l'onglet Capitalisation n'est pas valorisé")
+    is_filled_deliverable_indexation = fields.Boolean("Champ Livrable valorisé", store=True, commpute=compute, help="FAUX si le champ Livrable dans l'onglet Capitalisation n'est pas valorisé" )
+    is_filled_success_story_indexation = fields.Boolean("Champ Success story valorisé", store=True, compute=compute, help="FAUX si le champ Success story dans l'onglet Capitalisation n'est pa valorisé")
+    is_filled_commercial_reference_indexation = fields.Boolean("Champ Référence commerciale valorisé", store=True, compute=compute, help="FAUX si le champ Référence commerciale dans l'onglet Capitalisation n'est pas valorisé")

--- a/project_accounting/views/project.xml
+++ b/project_accounting/views/project.xml
@@ -36,7 +36,7 @@
                     <separator/>
                     <filter string="Archived" name="inactive" domain="[('active', '=', False)]"/>
 					<separator/>
-					<filter string="Projet avec au moins un élément à capitaliser" name="project_to_be_capitalized" domain="['|','|','|',('sales_proposal_indexation', 'in', ['to_be_capitalized']),('deliverable_indexation', 'in', ['to_be_capitalized_without_anonymization','to_be_capitalized_with_anonymization']),('success_story_indexation', 'in', ['yes_success_story']),('commercial_reference_indexation', 'in', ['yes_commercial_reference']),]"/>
+					<filter string="Projet avec au moins un élément à capitaliser ou non renseigné" name="project_to_be_capitalized" domain="['|','|','|',('sales_proposal_indexation', 'in', ['to_be_capitalized','not_specified']),('deliverable_indexation', 'in', ['to_be_capitalized_without_anonymization','to_be_capitalized_with_anonymization','not_specified']),('success_story_indexation', 'in', ['yes_success_story','not_specified']),('commercial_reference_indexation', 'in', ['yes_commercial_reference','not_specified']),]"/>
                     <group expand="0" string="Group By">
                         <filter string="Directeur de mission" name="Manager" context="{'group_by': 'project_director_employee_id'}"/>
                         <filter string="Client" name="Partner" context="{'group_by': 'partner_id'}"/>
@@ -149,6 +149,18 @@
 				<div class="alert alert-info mb-1" role="alert" attrs="{'invisible': [('other_part_marging_rate_controle_OK', '=', True)]}">
 					Le taux de marge actuel (sur prix de vente) sur les autres prestations est inférieur à la cote d'alerte.
 				</div>
+				<div class="alert alert-warning mb-1" role="alert" attrs="{'invisible': [('is_filled_sales_proposal_indexation', '=', True)]}">
+					Le champ "Proposition commerciale" dans l'onglet Capitalisation n'est pas renseigné
+				</div>
+				<div class="alert alert-warning mb-1" role="alert" attrs="{'invisible': [('is_filled_deliverable_indexation', '=', True)]}">
+					Le champ "Livrable" dans l'onglet Capitalisation n'est pas renseigné
+				</div>
+				<div class="alert alert-warning mb-1" role="alert" attrs="{'invisible': [('is_filled_commercial_reference_indexation', '=', True)]}">
+					Le champ "Référence commerciale" dans l'onglet Capitalisation n'est pas renseigné
+				</div>
+				<div class="alert alert-warning mb-1" role="alert" attrs="{'invisible': [('is_filled_success_story_indexation', '=', True)]}">
+					Le champ "Success story" dans l'onglet Capitalisation n'est pas renseigné
+				</div>
 				<field name="is_validated_order" invisible="1"/>
 				<field name="is_validated_book" invisible="1"/>
 				<field name="is_consistant_outsourcing" invisible="1"/>
@@ -159,6 +171,10 @@
 				<field name="is_outsource_part_amount_current" invisible="1"/>
 				<field name="is_affected_book" invisible="1"/>
 				<field name="other_part_marging_rate_controle_OK" invisible="1"/>
+				<field name="is_filled_sales_proposal_indexation" invisible="1"/>
+				<field name="is_filled_deliverable_indexation" invisible="1"/>
+				<field name="is_filled_commercial_reference_indexation" invisible="1"/>
+				<field name="is_filled_success_story_indexation" invisible="1"/>
 
 					
 				<div class="oe_title">


### PR DESCRIPTION
- suppression des contrôles 
- Ajout d'une valeur "Non renseigné" pour chacun des 4 champs
- Ajout des bandeaux jaunes si les champs ne sont pas correctement renseignés
- Evolution des valeurs oui/non sur les champs success story et référence commerciale
- modification du filtre "Projet avec au moins un élément à capitaliser ou non renseigné" afin d'afficher également les projets où les DM n'ont pas répondu à Margaux