### PR TITLE
[IMP] taz-common, dashboard_global: suivi des actions commerciales, a…

### DIFF
--- a/dashboard_global/views/dashboards.xml
+++ b/dashboard_global/views/dashboards.xml
@@ -15,7 +15,7 @@
                         <column>
                             <action string="Mes actions commerciales ouvertes avec une échéance sous 30 jours" name="%(taz-common.business_action_action)d" context="{'search_default_assigned_to_me' : 1, 'search_default_state_not_done_not_cancelled' : 1, 'search_default_j30' : 1}"/>
                             <action string="Mes objectifs de book annuels personnels" name="%(project_accounting.employee_book_goal_action)d" context="{'search_default_assigned_to_me' : 1}"/>
-                            <action string="Mes objectifs de RDV annuels personnels" name="%(taz-common.employee_business_action_goal_action)d" context="{'search_default_my_goals' : 1, 'search_default_group_year' : 1}"/>
+                            <action string="Mes objectifs de RDV annuels personnels" name="%(taz-common.employee_business_action_goal_action)d" context="{'search_default_my_goals' : 1, 'search_default_group_year' : 0}"/>
                             <action string="Les objectifs de prise de commande des comptes auxquels je contribue" name="%(taz-common.customer_book_goal_action)d" context="{'search_default_filter_my_customer_book_goal' : 1, 'search_default_filter_this_year' : True, 'search_default_group_rel_business_priority' : True}"/>
                         </column>
                     </board>

--- a/project_accounting/models/customer_book_goal.py
+++ b/project_accounting/models/customer_book_goal.py
@@ -6,13 +6,12 @@ class CustomerBookGoal(models.Model):
     """
     DOCUMENTATION ARCHITECTURALE :
     -----------------------------
-    Pourquoi surcharger ce modèle dans 'project_accounting' plutôt que dans 'taz-common' ?
 
     1. Rendre les colonnes triables (Odoo limitation) :
        Pour qu'une colonne calculée (compute) soit cliquable et triable dans une vue liste (tree),
        Odoo exige obligatoirement qu'elle soit stockée en base de données ('store=True').
 
-    2. La dépendance aux Projets (Le piège de taz-common) :
+    2. Pourquoi surcharger ce modèle dans 'project_accounting' plutôt que dans 'taz-common' ?
        Si l'on passe 'store=True' dans taz-common, Odoo va évaluer les champs au démarrage et 
        requérir l'accès à tous les champs mentionnés dans le @api.depends() pour construire ses abonnements.
        Or, de nombreux champs financiers cruciaux (stage_is_part_of_booking, prorated_revenue, etc.)

--- a/taz-common/models/business_action.py
+++ b/taz-common/models/business_action.py
@@ -136,7 +136,7 @@ class tazBusinessAction(models.Model):
 
     name = fields.Char('Titre', required=True)
     note = fields.Text('Note')
-    date_deadline = fields.Date('Échéance', index=True, required=False, default=fields.Date.context_today)
+    date_deadline = fields.Date('Échéance', index=True, required=True, default=fields.Date.context_today)
     owner_id = fields.Many2one('res.users', string='Affectée à', default=lambda self: self.env.user)
     user_ids = fields.Many2many(
         'res.users',
@@ -180,23 +180,25 @@ class tazBusinessAction(models.Model):
 
     def action_create_followup(self):
         self.ensure_one()
-        new_action = self.copy({
-            'name': _("Suite de : %s", self.name),
-            'parent_action_id': self.id,
-            'state': 'todo',
-            'conclusion': False,
-            'report_url': False,
-            'date_deadline': False,
-            'project_id': self.project_id.id,
-            'note': _("Action de suite pour : %s", self.name),
+        context = dict(self.env.context)
+        context.update({
+            'default_name': _("Suite de : %s", self.name),
+            'default_parent_action_id': self.id,
+            'default_state': 'todo',
+            'default_project_id': self.project_id.id if self.project_id else False,
+            'default_partner_id': self.partner_id.id if self.partner_id else False,
+            'default_owner_id': self.owner_id.id if self.owner_id else False,
+            'default_user_ids': [(6, 0, self.user_ids.ids)] if self.user_ids else False,
+            'default_is_rdv_to_be_taken_by_assistant': self.is_rdv_to_be_taken_by_assistant,
         })
+        
         return {
             'name': _('Action commerciale de suite'),
             'type': 'ir.actions.act_window',
             'res_model': 'taz.business_action',
-            'res_id': new_action.id,
             'view_mode': 'form',
             'target': 'current',
+            'context': context,
         }
 
     def open_record(self):

--- a/taz-common/models/employee_business_action_goal.py
+++ b/taz-common/models/employee_business_action_goal.py
@@ -48,14 +48,31 @@ class employeeBusinessActionGoal(models.Model):
         period_action_count = len(action_list)
         return action_list, period_action_count
 
+    def _get_period_pending_action(self):
+        self.ensure_one()
+        today = fields.Date.context_today(self)
+        end_date = datetime.date(int(self.reference_period), 12, 31)
+        
+        domain = [
+            ('date_deadline', '>=', today),
+            ('date_deadline', '<=', end_date),
+            ('action_type', '=', self.type),
+            ('user_ids', 'in', [self.user_id.id]),
+            ('state', 'not in', ['done', 'cancelled'])
+        ]
+        action_list = self.env['taz.business_action'].search(domain)
+        return action_list, len(action_list)
+
     def compute(self):
         for rec in self:
             if not rec.user_id or not rec.reference_period or not rec.type:
                 rec.period_action_count = 0
+                rec.period_pending_action_count = 0
                 rec.period_rate = 0
                 continue
             
             action_list, rec.period_action_count = rec._get_period_action()
+            pending_list, rec.period_pending_action_count = rec._get_period_pending_action()
             
             if rec.period_goal > 0:
                 rec.period_rate = (rec.period_action_count / rec.period_goal) * 100.0
@@ -69,7 +86,22 @@ class employeeBusinessActionGoal(models.Model):
 
         return {
             'type': 'ir.actions.act_window',
-            'name': _('Détail des actions de %s pour l\'année %s' % (self.user_id.name, self.reference_period)),
+            'name': _('Détail des actions réalisées par %s pour l\'année %s' % (self.user_id.name, self.reference_period)),
+            'res_model': 'taz.business_action',
+            'view_mode': 'list,form',
+            'target': 'current',
+            'domain': domain,
+            'context': {'create': False},
+        }
+
+    def action_view_pending_details(self):
+        self.ensure_one()
+        action_list, period_action_count = self._get_period_pending_action()
+        domain = [('id', 'in', action_list.ids)]
+
+        return {
+            'type': 'ir.actions.act_window',
+            'name': _('Détail des actions prévues de %s pour l\'année %s' % (self.user_id.name, self.reference_period)),
             'res_model': 'taz.business_action',
             'view_mode': 'list,form',
             'target': 'current',
@@ -87,6 +119,7 @@ class employeeBusinessActionGoal(models.Model):
     
     period_goal = fields.Integer("Objectif annuel")
     period_action_count = fields.Integer("Réalisé à date", compute='compute')
+    period_pending_action_count = fields.Integer("Prévu (futur)", compute='compute')
     period_rate = fields.Float("Ratio atteint/objectif (%)", compute='compute')
     
     company_id = fields.Many2one('res.company', string='Société', required=True, default=lambda self: self.env.company)

--- a/taz-common/models/res_partner.py
+++ b/taz-common/models/res_partner.py
@@ -104,10 +104,10 @@ class tazResPartner(models.Model):
      @api.depends('business_action_ids.date_deadline', 'business_action_ids.state')
      def _compute_date_last_business_action(self_list):
          for self in self_list :
-             res = None
+             res = False
              for action in self.business_action_ids:
-                 if action.state == 'done' :
-                     if res == None or action.date_deadline > res:
+                 if action.state == 'done' and action.date_deadline:
+                     if not res or action.date_deadline > res:
                          res = action.date_deadline
              self.date_last_business_action = res
 

--- a/taz-common/views/employee_business_action_goal_views.xml
+++ b/taz-common/views/employee_business_action_goal_views.xml
@@ -10,10 +10,12 @@
                     <field name="user_id"/>
                     <field name="reference_period"/>
                     <field name="type"/>
-                    <field name="period_goal" sum="Total"/>
-                    <field name="period_action_count" sum="Total"/>
-                    <button type="object" name="action_view_details" icon="fa-eye" title="Détails des actions"/>
+                    <field name="period_goal" sum="Total" width="150px"/>
+                    <field name="period_action_count" sum="Total" width="150px"/>
+                    <button type="object" name="action_view_details" icon="fa-eye" title="Détails des actions réalisées"/>
                     <field name="period_rate" widget="progressbar"/>
+                    <field name="period_pending_action_count" sum="Total" width="150px"/>
+                    <button type="object" name="action_view_pending_details" icon="fa-eye" title="Détails des actions prévues"/>
                     <field name="note" optional="hide"/>
                 </list>
             </field>
@@ -35,6 +37,7 @@
                                 <field name="period_goal"/>
                                 <field name="period_action_count"/>
                                 <field name="period_rate" widget="progressbar"/>
+                                <field name="period_pending_action_count"/>
                                 <field name="company_id" groups="base.group_multi_company"/>
                             </group>
                         </group>
@@ -68,14 +71,14 @@
         </record>
 
         <record id="employee_business_action_goal_action" model="ir.actions.act_window">
-            <field name="name">Objectifs de RDV par collaborateur</field>
+            <field name="name">Objectifs d'actions commerciales par collaborateur</field>
             <field name="res_model">taz.employee_business_action_goal</field>
             <field name="view_mode">list,form</field>
             <field name="search_view_id" ref="employee_business_action_goal_view_search"/>
-            <field name="context">{'search_default_this_year': 1, 'search_default_group_user': 1}</field>
+            <field name="context">{'search_default_this_year': 1, 'search_default_group_user': 0}</field>
         </record>
 
-        <menuitem name="Objectifs RDV par collaborateur" 
+        <menuitem name="Objectifs d'actions commerciales par collaborateur" 
                   id="menu_employee_business_action_goal" 
                   parent="taz-common.business_action" 
                   action="employee_business_action_goal_action" 


### PR DESCRIPTION
…ctions prévues et correctifs

Ces modifications apportent des améliorations fonctionnelles et resolvent des erreurs d’evaluation :

- taz-common (business_action) : le champ date_deadline devient obligatoire. La logique de creation d’une action de suite est refondue pour utiliser les cles default_* via le contexte, garantissant une meilleure portabilite.
- taz-common (employee_business_action_goal) : ajout du sous-total period_pending_action_count et de son action associee pour deduire et consulter les actions commerciales prevues (futures et non annulees) sur une annee.
- taz-common (res_partner) : correction d’un bug provoquant un TypeError. Le traitement s’assure que res vaut False (et non None) et qu’une date de fin existe bien avant d’operer une comparaison superieure strict.
- taz-common (vues) : ajustement du nommage, passant de RDV a des objectifs d’actions commerciales globales, et ajustement des colonnes pour un affichage plus aeré.
- dashboard_global : retrait du groupement par annee actif par defaut dans l’action associee.
- project_accounting : formatage du commentaire dans le modele customer_book_goal.