### PR TITLE
[IMP] taz-common: ajustements de saisie, de cles de tri et semantique

### DIFF
--- a/taz-common/models/business_action.py
+++ b/taz-common/models/business_action.py
@@ -136,7 +136,7 @@ class tazBusinessAction(models.Model):
 
     name = fields.Char('Titre', required=True)
     note = fields.Text('Note')
-    date_deadline = fields.Date('Échéance', index=True, required=True, default=fields.Date.context_today)
+    date_deadline = fields.Date('Échéance', index=True, required=True)
     owner_id = fields.Many2one('res.users', string='Affectée à', default=lambda self: self.env.user)
     user_ids = fields.Many2many(
         'res.users',

--- a/taz-common/models/employee_business_action_goal.py
+++ b/taz-common/models/employee_business_action_goal.py
@@ -7,7 +7,7 @@ import datetime
 class employeeBusinessActionGoal(models.Model):
     _name = "taz.employee_business_action_goal"
     _description = "Employee Business Action Goal"
-    _order = "reference_period desc"
+    _order = "reference_period desc, user_id"
     _sql_constraints = [
         ('user_year_type_uniq', 'UNIQUE (user_id, reference_period, type)', 
          "Impossible d'avoir deux objectifs pour le même utilisateur, la même année et le même type d'action.")
@@ -101,7 +101,7 @@ class employeeBusinessActionGoal(models.Model):
 
         return {
             'type': 'ir.actions.act_window',
-            'name': _('Détail des actions prévues de %s pour l\'année %s' % (self.user_id.name, self.reference_period)),
+            'name': _('Détail des actions futures prévues de %s pour l\'année %s' % (self.user_id.name, self.reference_period)),
             'res_model': 'taz.business_action',
             'view_mode': 'list,form',
             'target': 'current',
@@ -120,7 +120,7 @@ class employeeBusinessActionGoal(models.Model):
     period_goal = fields.Integer("Objectif annuel")
     period_action_count = fields.Integer("Réalisé à date", compute='compute')
     period_pending_action_count = fields.Integer("Prévu (futur)", compute='compute')
-    period_rate = fields.Float("Ratio atteint/objectif (%)", compute='compute')
+    period_rate = fields.Float("Ratio réalisé/objectif (%)", compute='compute')
     
     company_id = fields.Many2one('res.company', string='Société', required=True, default=lambda self: self.env.company)
     name = fields.Char("Libellé", compute='_compute_name', store=True)


### PR DESCRIPTION
- business_action : suppression de la valeur par defaut sur le champ date_deadline (echeance) pour contraindre l'utilisateur a choisir explicitement une date au lieu de valider la date par defaut.
- employee_business_action_goal : ajustement semantique du champ period_rate (Ratio realise au lieu de Ratio atteint) et precision ajoutée sur le titre de l'action de renvoi pour les actions prevues. Amelioration de l'affichage par defaut en ajoutant le user_id dans l'ordre de tri de base (_order).