### PR TITLE
[IMP] napta_connector, project_accounting: migration et paramétrage d…

### DIFF
--- a/napta_connector/__manifest__.py
+++ b/napta_connector/__manifest__.py
@@ -18,6 +18,7 @@
     'data': [
         'security/ir.model.access.csv',
         'data/cron_sync.xml',
+        'data/project_stage_data.xml',
         'views/napta.xml',
         'views/project.xml',
         'views/wizard_timesheet_mass_validation.xml',

--- a/napta_connector/data/project_stage_data.xml
+++ b/napta_connector/data/project_stage_data.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+    <data noupdate="1">
+        <record id="project.project_project_stage_0" model="project.project.stage">
+            <field name="napta_id">5</field>
+            <field name="transmit_to_napta">False</field>
+        </record>
+        <record id="project_accounting.project_project_stage_7" model="project.project.stage">
+            <field name="napta_id">10</field>
+            <field name="transmit_to_napta">True</field>
+        </record>
+        <record id="project_accounting.project_project_stage_6" model="project.project.stage">
+            <field name="napta_id">9</field>
+            <field name="transmit_to_napta">True</field>
+        </record>
+        <record id="project_accounting.project_project_stage_9" model="project.project.stage">
+            <field name="napta_id">12</field>
+            <field name="transmit_to_napta">True</field>
+        </record>
+        <record id="project.project_project_stage_1" model="project.project.stage">
+            <field name="napta_id">6</field>
+            <field name="transmit_to_napta">True</field>
+        </record>
+        <record id="project_accounting.project_project_stage_8" model="project.project.stage">
+            <field name="napta_id">11</field>
+            <field name="transmit_to_napta">False</field>
+        </record>
+        <record id="project.project_project_stage_2" model="project.project.stage">
+            <field name="napta_id">7</field>
+            <field name="transmit_to_napta">False</field>
+        </record>
+        <record id="project.project_project_stage_3" model="project.project.stage">
+            <field name="napta_id">8</field>
+            <field name="transmit_to_napta">False</field>
+        </record>
+    </data>
+</odoo>

--- a/napta_connector/models/napta.py
+++ b/napta_connector/models/napta.py
@@ -402,8 +402,7 @@ class naptaProject(models.Model):
         projects = super().create(vals)
         for rec in projects:
             if not rec.is_prevent_napta_creation:
-                stage_froid = self.env.ref('project.project_project_stage_0', raise_if_not_found=False)
-                if not rec.napta_id and stage_froid and rec.stage_id == stage_froid:
+                if not rec.napta_id and not rec.stage_id.transmit_to_napta:
                     continue
                 rec.napta_to_sync = True
                 try : 
@@ -436,8 +435,7 @@ class naptaProject(models.Model):
             if any(field in ODOO_TO_NAPTA_PROJECT_FIELD_LIST for field in vals.keys()):
                 _logger.info("==== Champs de l'objet project.project modifiés : %s" % str(vals.keys()))
                 if not rec.is_prevent_napta_creation and not self.env.context.get('ignore_napta_write') and rec.partner_id :
-                    stage_froid = self.env.ref('project.project_project_stage_0', raise_if_not_found=False)
-                    if not rec.napta_id and stage_froid and rec.stage_id == stage_froid:
+                    if not rec.napta_id and not rec.stage_id.transmit_to_napta:
                         continue
                     rec.with_context(ignore_napta_write=True).napta_to_sync = True
                     try:
@@ -640,6 +638,7 @@ class naptaProjectStage(models.Model):
         ('napta_id__uniq', 'UNIQUE (napta_id)',  "Impossible d'enregistrer deux objects avec le même Napta ID.")
     ]
     napta_id = fields.Char("Napta ID", copy=False)
+    transmit_to_napta = fields.Boolean("Transmettre à Napta", default=True, help="Si cette case est décochée, les projets qui sont dans ce statut ne seront pas transmis à Napta, sauf s'ils ont déjà été transmis au paravant (c'est à dire s'ils ont déjà un napta_id de défini).")
 
     def create_update_napta(self):
         #_logger.info('---- Create or update Napta project stage')

--- a/napta_connector/views/napta.xml
+++ b/napta_connector/views/napta.xml
@@ -136,13 +136,25 @@
                 </field>
             </field>
         </record>
-        <record id="res_project_stage_napta_view_form_inherit" model="ir.ui.view">
-            <field name="name">Project stage</field>
+        <record id="project_project_stage_view_list_napta_inherit" model="ir.ui.view">
+            <field name="name">project.project.stage.view.list.napta.inherit</field>
             <field name="model">project.project.stage</field>
             <field name="inherit_id" ref="project.project_project_stage_view_tree"/>
             <field name="arch" type="xml">
                 <field name="name" position="after">
                     <field name="napta_id" readonly="1"/>
+                    <field name="transmit_to_napta"/>
+                </field>
+            </field>
+        </record>
+        <record id="project_project_stage_view_form_napta_inherit" model="ir.ui.view">
+            <field name="name">project.project.stage.view.form.napta.inherit</field>
+            <field name="model">project.project.stage</field>
+            <field name="inherit_id" ref="project.project_project_stage_view_form"/>
+            <field name="arch" type="xml">
+                <field name="mail_template_id" position="after">
+                    <field name="napta_id" readonly="1"/>
+                    <field name="transmit_to_napta"/>
                 </field>
             </field>
         </record>

--- a/project_accounting/data/project_data.xml
+++ b/project_accounting/data/project_data.xml
@@ -31,5 +31,79 @@
             <field name="interval_type">months</field>
             <field name="nextcall" eval="datetime.now().replace(year=datetime.now().year+1, month=1, day=1, hour=4, minute=0, second=0).strftime('%Y-%m-%d %H:%M:%S')"/>
         </record>
+        <record id="project.project_project_stage_0" model="project.project.stage">
+            <field name="name">1-Avant-vente froid (non transmises à Napta)</field>
+            <field name="sequence">10</field>
+            <field name="active">True</field>
+            <field name="fold" eval="False"/>
+            <field name="is_part_of_booking" eval="False"/>
+            <field name="state">before_launch</field>
+            <field name="color">decoration-info</field>
+            <field name="allowed_next_stage_ids" eval="[(6, 0, [ref('project.project_project_stage_3'), ref('project_project_stage_6'), ref('project_project_stage_7'), ref('project_project_stage_8')])]"/>
+        </record>
+        <record id="project_project_stage_7" model="project.project.stage">
+            <field name="name">2-Avant-vente chaud</field>
+            <field name="sequence">11</field>
+            <field name="active">True</field>
+            <field name="fold" eval="False"/>
+            <field name="is_part_of_booking" eval="False"/>
+            <field name="state">before_launch</field>
+            <field name="color">decoration-info</field>
+            <field name="allowed_next_stage_ids" eval="[(6, 0, [ref('project.project_project_stage_0'), ref('project.project_project_stage_3'), ref('project_project_stage_8'), ref('project_project_stage_6')])]"/>
+        </record>
+        <record id="project_project_stage_6" model="project.project.stage">
+            <field name="name">3-Accord client</field>
+            <field name="sequence">13</field>
+            <field name="active">True</field>
+            <field name="fold" eval="False"/>
+            <field name="is_part_of_booking" eval="True"/>
+            <field name="state">before_launch</field>
+            <field name="color">decoration-warning</field>
+        </record>
+        <record id="project.project_project_stage_1" model="project.project.stage">
+            <field name="name">4-Commandé</field>
+            <field name="sequence">15</field>
+            <field name="active">True</field>
+            <field name="fold" eval="False"/>
+            <field name="is_part_of_booking" eval="True"/>
+            <field name="state">launched</field>
+            <field name="color">decoration-success</field>
+        </record>
+        <record id="project_project_stage_9" model="project.project.stage">
+            <field name="name">5-Production terminée</field>
+            <field name="sequence">15</field>
+            <field name="active">True</field>
+            <field name="fold" eval="False"/>
+            <field name="is_part_of_booking" eval="True"/>
+            <field name="state">launched</field>
+            <field name="color">decoration-primary</field>
+        </record>
+        <record id="project_project_stage_8" model="project.project.stage">
+            <field name="name">Perdu</field>
+            <field name="sequence">17</field>
+            <field name="active">True</field>
+            <field name="fold" eval="True"/>
+            <field name="is_part_of_booking" eval="False"/>
+            <field name="state">closed</field>
+            <field name="color">decoration-danger</field>
+        </record>
+        <record id="project.project_project_stage_2" model="project.project.stage">
+            <field name="name">6-Clos comptablement</field>
+            <field name="sequence">20</field>
+            <field name="active">True</field>
+            <field name="fold" eval="True"/>
+            <field name="is_part_of_booking" eval="True"/>
+            <field name="state">closed</field>
+            <field name="color">decoration-muted</field>
+        </record>
+        <record id="project.project_project_stage_3" model="project.project.stage">
+            <field name="name">Annulé</field>
+            <field name="sequence">25</field>
+            <field name="active">True</field>
+            <field name="fold" eval="True"/>
+            <field name="is_part_of_booking" eval="False"/>
+            <field name="state">closed</field>
+            <field name="color">decoration-danger</field>
+        </record>
     </data>
 </odoo>


### PR DESCRIPTION
…es étapes de projet

Ce commit harmonise la gestion des étapes de projet entre le métier et le connecteur externe, tout en sécurisant les données existantes.

napta_connector :
- Ajout du champ 'Transmettre à Napta' (transmit_to_napta) sur les étapes pour piloter l'envoi des projets sans codage en dur.
- Mise à jour de la logique de synchronisation pour utiliser ce paramètre.
- Création d'un fichier de données dédié pour les IDs Napta.
- Amélioration des vues liste et formulaire pour gérer ces paramètres.

project_accounting :
- Intégration complète des définitions d'étapes dans les fichiers de données du module (noupdate=1).
- Migration des IDs '__export__' vers des IDs propres au module pour garantir la stabilité et éviter les erreurs de chargement Odoo 18.
- Report de l'ensemble des champs métier (comptabilisation dans le book, états, couleurs et étapes suivantes autorisées).