### PR TITLE
[FIX] project_accounting: securisation des clotures et avancements

### DIFF
--- a/project_accounting/models/project_accounting_closing.py
+++ b/project_accounting/models/project_accounting_closing.py
@@ -1,3 +1,4 @@
+from dateutil import relativedelta
 from odoo import models, fields, api
 from odoo.exceptions import UserError, ValidationError
 import logging
@@ -36,13 +37,16 @@ class projectAccountingClosing(models.Model):
         # sinon, c'est le dernier jour du mois suivant celui de la dernière cloture
         return (last_closing_date + relativedelta(months=2)).replace(day=1) - datetime.timedelta(1)
 
-    @api.constrains('closing_date', 'company_id', 'is_validated')
+    @api.constrains('closing_date', 'company_id')
     def _check_closing_date(self):
         for rec in self:
             accounting_closing_ids = self.env['project.accounting_closing'].search([('project_id', '=', rec.project_id.id)], order="closing_date desc")
             if accounting_closing_ids[0].id != rec.id:
                 raise ValidationError(_("Il n'est pas possible de saisir une date de clôture antérieure à la dernière cloture enregistrée pour ce projet."))
-
+    
+    @api.constrains('closing_date', 'company_id', 'is_validated')
+    def _check_accounting_lock_dates(self):
+        for rec in self:
             # Vérification des dates de verrouillage comptable
             if rec.closing_date:
                 company = rec.company_id
@@ -73,21 +77,63 @@ class projectAccountingClosing(models.Model):
         for rec in closing:
             if rec.project_id:
                 rec.original_stage_id = rec.project_id.stage_id.id
+            
+            # Chez Tasmane, l'entrée dans l'alliance a conduit à basculer à une reconnaissance du CA à l'avancement
+            #   - pour les mois de janvier / février / mars 2026, Denis à fait les clotures habituelles mais a desocké tout le stock chaque mois
+            #   - fin mars 2026, on a créé l'objet project.progress et on l'a instancié pour le T1 2026. Un script a été xecuté pour retomber sur le CA déclaré
+            #   - à partir de la clôture du 31/03/2026, on a mis valuation_from_progress=True et on calcule automatiquement les provisions à parir des project.progress
+            if rec.closing_date and rec.closing_date >= datetime.date(2026, 3, 1) and not rec.is_validated:
+                rec.valuation_from_progress = True
+                ###### Auto-creation of project.progress records
+                rec.create_project_progress()
+
         return closing
 
 
+    def create_project_progress(self):
+                self.ensure_one()
+                # 1. For each outsourcing link
+                for link in self.project_id.project_outsourcing_link_ids:
+                    progress = self.env['project.progress'].search([
+                        ('accounting_closing_id', '=', self.id),
+                        ('outsourcing_link_id', '=', link.id)
+                    ], limit=1)
+                    if not progress:
+                        outsourcing_progress_dic = {
+                            'accounting_closing_id': self.id,
+                            'outsourcing_link_id': link.id,
+                        }
+                        _logger.info("Creating project progress : %s " % str(outsourcing_progress_dic))
+                        new_progress_outsourcing = self.env['project.progress'].create(outsourcing_progress_dic)
+                        # Après le create, previous_progress_id est résolu.
+                        # Pour le type 'autre', l'écriture à 0 déclenche _inverse_qty_period qui positionne
+                        # outsourcing_product_qty = previous.outsourcing_product_qty + 0
+                        # => l'avancement cumulé est repris de la période précédente.
+                        # Pour le type S/T, on laisse à 0 par défaut pour forcer la saisie du nouvel avancement.
+                        if link.link_type == 'outsourcing':
+                            new_progress_outsourcing.outsourcing_product_qty_period = 0.0
+                
+                # 2. For internal production
+                napta_id = getattr(self.project_id, 'napta_id', False)
+                if napta_id or self.project_id.company_part_amount_current != 0.0:
+                    _logger.info("XXXXXX Creating project progress for internal production napta_id=%s, company_part_amount_current=%s" % (napta_id, self.project_id.company_part_amount_current))
+                    internal_progress = self.env['project.progress'].search([
+                        ('accounting_closing_id', '=', self.id),
+                        ('outsourcing_link_id', '=', False)
+                    ], limit=1)
+                    if not internal_progress:
+                        internal_progress_dic = {
+                            'accounting_closing_id': self.id,
+                            'outsourcing_link_id': False,
+                        }
+                        _logger.info("Creating project progress : %s " % str(internal_progress_dic))
+                        self.env['project.progress'].create(internal_progress_dic)
+                        
 
     def write(self, vals):
+        self._check_can_write(vals)
         for rec in self :
-            if rec.next_closing :
-                raise ValidationError(_("Il n'est pas possible de modifier cette clôture car une clôture postérieure existe pour ce projet."))
-            if rec.is_validated :
-                for val_key in vals.keys():
-                    if val_key not in ['is_validated', 'rel_project_stage_id', 'rel_project_user_id', 'rel_project_manager_user_id', 'name']:
-                    #il faut pouvoir écrire s'il on dévalide et lorsque le projet change de statut (rel_project_stage_id est stocké pour permettre de grouper sur cet attribut)
-                        raise ValidationError(_("Il n'est pas possible de modifier cette clôture car elle est validée %s (ID = %s).\n\nTentative de modification des attributs suivants, dont au moins un n'est pas modifiable une fois la clôture validée : %s." % (rec.name, rec.id, ', '.join(vals.keys()))))
-            
-            # Nouvelle contrainte : on ne peut pas valider la clôture si des avancements ne sont pas validés
+            # On ne peut pas valider la clôture si des avancements ne sont pas validés
             if vals.get('is_validated'):
                 if len(vals) > 1:
                     raise ValidationError(_("Il n'est pas possible de valider la clôture et de modifier d'autres champs en même temps. Veuillez d'abord enregistrer vos modifications, puis valider la clôture."))
@@ -100,6 +146,20 @@ class projectAccountingClosing(models.Model):
                     raise ValidationError(_("Impossible de valider la clôture car les avancements suivants ne sont pas validés : %s") % progress_names)
         super().write(vals)
 
+
+    def _check_can_write(self, vals=None):
+        for rec in self :
+            if rec.next_closing :
+                raise ValidationError(_("Il n'est pas possible de modifier cette clôture car une clôture postérieure existe pour ce projet."))
+            if rec.is_validated :
+                if vals is None:
+                    raise ValidationError(_("Il n'est pas possible de modifier cette clôture car elle est validée %s (ID = %s)." % (rec.name, rec.id)))
+                else :
+                    for val_key in vals.keys():
+                        if val_key not in ['is_validated', 'rel_project_stage_id', 'rel_project_user_id', 'rel_project_manager_user_id', 'name']:
+                        #il faut pouvoir écrire s'il on dévalide et lorsque le projet change de statut (rel_project_stage_id est stocké pour permettre de grouper sur cet attribut)
+                            raise ValidationError(_("Il n'est pas possible de modifier cette clôture car elle est validée %s (ID = %s).\n\nTentative de modification des attributs suivants, dont au moins un n'est pas modifiable une fois la clôture validée : %s." % (rec.name, rec.id, ', '.join(vals.keys()))))
+            
 
     def unlink(self):
         for rec in self:
@@ -126,17 +186,81 @@ class projectAccountingClosing(models.Model):
                 raise ValidationError(_("Clôture %s : le solde FNP ne peut pas être positif (%s).") % (rec.name, rec.fnp_balance))
     """
 
+    def check_provisions_consistency(self):
+        for rec in self :
+            if rec.object_progress_ids :
+                # 1. CA Brut (Somme des variations de revenus)
+                if rec.closing_date > datetime.date(2025, 12, 31):
+                    if abs(rec.gross_revenue - sum(rec.object_progress_ids.mapped('progress_revenue_amount_period'))) > 0.01 :
+                        _logger.info("; %s ; %s ; ATTENTION La somme des CA bruts DE LA PÉRIODE des avancements n'est pas égale au CA brut de la cloture." % (rec.project_id.display_name, rec.closing_date))
+                
+                somme_ca_cumulés_adv = sum(rec.object_progress_ids.mapped('progress_revenue_amount'))
+                # Recherche de toutes les clôtures du même projet dont la date est <= à la clôture actuelle
+                all_previous_closings = self.env['project.accounting_closing'].search([
+                    ('project_id', '=', rec.project_id.id),
+                    ('closing_date', '<=', rec.closing_date)
+                ])
+                # Somme des CA bruts de ces clôtures
+                somme_ca_bruts_historiques = sum(all_previous_closings.mapped('gross_revenue'))
+                if abs(somme_ca_cumulés_adv - somme_ca_bruts_historiques) > 0.01 :
+                    _logger.info("; %s ; %s ; ATTENTION La somme des CA bruts CUMULES des avancements n'est pas égale à la somme des CA bruts des clôtures antérieures ou égales à celle-ci.; %s ; %s ;  %s" % (rec.project_id.display_name, rec.closing_date, somme_ca_cumulés_adv, somme_ca_bruts_historiques, somme_ca_cumulés_adv-somme_ca_bruts_historiques))
+
+                # 2. FAE / PCA (Logique d'écart cumulé)
+                total_adv_revenue = sum(rec.object_progress_ids.mapped('progress_revenue_amount'))
+                cumul_invoiced = rec.get_invoice_period(rec.project_id, [], rec.closing_date)[0]
+                
+                revenue_gap = total_adv_revenue - cumul_invoiced
+                if revenue_gap > 0:
+                    computed_fae_period_amount = revenue_gap - rec.fae_previous_balance
+                    computed_pca_period_amount = -rec.pca_previous_balance
+                else:
+                    computed_pca_period_amount = revenue_gap - rec.pca_previous_balance
+                    computed_fae_period_amount = -rec.fae_previous_balance
+                if rec.closing_date > datetime.date(2025, 12, 31):
+                    if abs(computed_fae_period_amount - rec.fae_period_amount) > 0.01 :
+                        _logger.info("; %s ; %s ; Le montant calculé de FAE est différent de celui qui a été saisi sur la cloture. L'algo le redressera sur le premier mois calculé automatiquement." % (rec.project_id.display_name, rec.closing_date))
+                    if abs(computed_pca_period_amount - rec.pca_period_amount) > 0.01 :
+                        _logger.info("; %s ; %s ; Le montant calculé de PCA est différent de celui qui a été saisi sur la cloture. L'algo le redressera sur le premier mois calculé automatiquement." % (rec.project_id.display_name, rec.closing_date))
+
+
+                # 3. CCA / FNP (Somme des provisions des lignes)
+                if rec.closing_date > datetime.date(2025, 12, 31):
+                    if abs(rec.cca_balance - sum(rec.object_progress_ids.mapped('cca_balance'))) > 0.01 :
+                        _logger.info("; %s ; %s ; ATTENTION La somme des soldes de CCA des avancements n'est pas égale au solde de CCA de la cloture. ; %s ; %s ;  %s" % (rec.project_id.display_name, rec.closing_date, rec.cca_balance, sum(rec.object_progress_ids.mapped('cca_balance')), rec.cca_balance-sum(rec.object_progress_ids.mapped('cca_balance'))))
+                    if abs(rec.fnp_balance - sum(rec.object_progress_ids.mapped('fnp_balance'))) > 0.01 :
+                        _logger.info("; %s ; %s ; ATTENTION La somme des soldes de FNP des avancements n'est pas égale au solde de FNP de la cloture. ; %s ; %s ;  %s" % (rec.project_id.display_name, rec.closing_date, rec.fnp_balance, sum(rec.object_progress_ids.mapped('fnp_balance')), rec.fnp_balance-sum(rec.object_progress_ids.mapped('fnp_balance'))))
+
+
+                # 4. Déstockage total au fur et à mesure
+                if rec.production_balance != 0 :
+                    _logger.info("; %s ; %s ; Le solde de production interne n'est pas nulle. L'algo le mettra à 0 automatiquement sur le premier mois calculé automatiquement." % (rec.project_id.display_name, rec.closing_date))
+                if rec.production_external_balance != 0 :
+                    _logger.info("; %s ; %s ; Le solde de production externe n'est pas nulle. L'algo le mettra à 0 automatiquement sur le premier mois calculé automatiquement." % (rec.project_id.display_name, rec.closing_date))
+                
+                # Contrôle de cohérence sur les achats (uniquement si valorisé par l'avancement)
+                total_progress_purchase = sum(rec.object_progress_ids.mapped('purchase_period_amount'))
+                if abs(rec.purchase_period_amount - total_progress_purchase) > 0.01 :
+                    _logger.info("; %s ; %s ; ATTENTION La somme des achats des avancements n'est pas égale aux achats de la cloture." % (rec.project_id.display_name, rec.closing_date))
+                
+                if rec.fae_balance < 0:
+                    _logger.info("; %s ; %s ; Le solde FAE ne peut pas être négatif (%s)." % (rec.project_id.display_name, rec.closing_date, rec.fae_balance))
+                if rec.pca_balance > 0:
+                    _logger.info("; %s ; %s ; Le solde PCA ne peut pas être positif (%s)." % (rec.project_id.display_name, rec.closing_date, rec.pca_balance))
+                if rec.cca_balance < 0:
+                    _logger.info("; %s ; %s ; Le solde CCA ne peut pas être négatif (%s)." % (rec.project_id.display_name, rec.closing_date, rec.cca_balance))
+                if rec.fnp_balance > 0:
+                    _logger.info("; %s ; %s ; Le solde FNP ne peut pas être positif (%s)." % (rec.project_id.display_name, rec.closing_date, rec.fnp_balance))
+
 
     @api.depends('project_id', 'project_id.name', 'is_validated', 'closing_date', 'valuation_from_progress', 
                  'object_progress_ids.progress_revenue_amount_period', 'object_progress_ids.purchase_period_amount', 
                  'object_progress_ids.cca_period_amount', 'object_progress_ids.fnp_period_amount')
     def compute(self):
+        #self.check_provisions_consistency()
+        #return
         _logger.info('-- compute project_accounting_closing')
         for rec in self :
-            if rec.is_validated: 
-                # TODO : protection contre les modification du passé lors de l'initialisation des nouveaux calculs par l'ORM (qui ne passe pas par le write surarché ci-desus)
-                # A retirer une fois que l'ORM aura initialisé les nouveaux champs
-                continue
+            rec._check_can_write()
 
             proj_id = rec.project_id #quand on applique la fonction WRITE
             if '<NewId origin=' in str(proj_id) : #pour avoir la cloture précédente et les valeur de facturation du mois lorsque l'on modifie n'importe quel attribut de la popup (c'est à dire quand on est en mon onchange)
@@ -155,52 +279,6 @@ class projectAccountingClosing(models.Model):
                 previous_closing = previous_accounting_closing_ids[0]
                 previous_closing_date_filter.append(('date', '>', previous_closing.closing_date))
             rec.previous_closing = previous_closing
-
-
-            # Chez Tasmane, l'entrée dans l'alliance a conduit à basculer à une reconnaissance du CA à l'avancement
-            #   - pour les mois de janvier / février / mars 2026, Denis à fait les clotures habituelles mais a desocké tout le stock chaque mois
-            #   - fin mars 2026, on a créé l'objet project.progress et on l'a instancié pour le T1 2026. Un script a été xecuté pour retomber sur le CA déclaré
-            #   - à partir de la clôture du 31/03/2026, on a mis valuation_from_progress=True et on calcule automatiquement les provisions à parir des project.progress
-            if rec.closing_date and rec.closing_date >= datetime.date(2026, 3, 1) and not rec.is_validated:
-                rec.valuation_from_progress = True
-            
-            # Auto-creation of project.progress records
-            if rec.valuation_from_progress and not(isinstance(rec.id, models.NewId)):
-                # 1. For each outsourcing link
-                for link in proj_id.project_outsourcing_link_ids:
-                    progress = self.env['project.progress'].search([
-                        ('accounting_closing_id', '=', rec.id),
-                        ('outsourcing_link_id', '=', link.id)
-                    ], limit=1)
-                    if not progress:
-                        outsourcing_progress_dic = {
-                            'accounting_closing_id': rec.id,
-                            'outsourcing_link_id': link.id,
-                        }
-                        _logger.info("Creating project progress : %s " % str(outsourcing_progress_dic))
-                        new_progress_outsourcing = self.env['project.progress'].create(outsourcing_progress_dic)
-                        # Après le create, previous_progress_id est résolu.
-                        # Pour le type 'autre', l'écriture à 0 déclenche _inverse_qty_period qui positionne
-                        # outsourcing_product_qty = previous.outsourcing_product_qty + 0
-                        # => l'avancement cumulé est repris de la période précédente.
-                        # Pour le type S/T, on laisse à 0 par défaut pour forcer la saisie du nouvel avancement.
-                        if link.link_type == 'outsourcing':
-                            new_progress_outsourcing.outsourcing_product_qty_period = 0.0
-                
-                # 2. For internal production
-                napta_id = getattr(rec.project_id, 'napta_id', False)
-                if napta_id or rec.project_id.company_part_amount_current != 0.0:
-                    internal_progress = self.env['project.progress'].search([
-                        ('accounting_closing_id', '=', rec.id),
-                        ('outsourcing_link_id', '=', False)
-                    ], limit=1)
-                    if not internal_progress:
-                        internal_progress_dic = {
-                            'accounting_closing_id': rec.id,
-                            'outsourcing_link_id': False,
-                        }
-                        _logger.info("Creating project progress : %s " % str(internal_progress_dic))
-                        self.env['project.progress'].create(internal_progress_dic)
 
 
 

--- a/project_accounting/models/project_progress.py
+++ b/project_accounting/models/project_progress.py
@@ -119,18 +119,25 @@ class ProjectProgress(models.Model):
     # ===================================================================
     def write(self, vals):
         for rec in self:
-            if rec.accounting_closing_id.is_validated:
-                raise ValidationError(_("Il n'est pas possible de modifier cet avancement car il est lié à une clôture validée."))
-            if rec.next_progress:
-                raise ValidationError(_("Il n'est pas possible de modifier cet avancement car un avancement postérieur existe."))
-            if rec.is_validated:
+            rec._check_can_write(vals)
+        res = super().write(vals)
+        return res
+
+    def _check_can_write(self, vals=None):
+        # On est obligé d'appeler cette fonction dans chaque fonction @depends car elles bypass write()
+        #       Avant on ne contrôlait que dans write() et certaines valeur on été réécrites alors quel l'objet était déjà validé
+        self.ensure_one()
+        if self.accounting_closing_id.is_validated:
+            raise ValidationError(_("Il n'est pas possible de modifier cet avancement car il est lié à une clôture validée."))
+        if self.next_progress:
+            raise ValidationError(_("Il n'est pas possible de modifier cet avancement car un avancement postérieur existe."))
+        if self.is_validated:
+            if vals is None:
+                raise ValidationError(_("Il n'est pas possible de modifier cet avancement car il est validé."))
+            else:
                 for val_key in vals.keys():
                     if val_key not in ['is_validated', 'message_follower_ids', 'message_ids', 'activity_ids', 'message_attachment_ids', 'message_main_attachment_id']:
                         raise ValidationError(_("Il n'est pas possible de modifier cet avancement car il est validé.\n\nTentative de modification de l'attribut : %s") % val_key)
-        
-        res = super().write(vals)
-
-        return res
 
     def unlink(self):
         for rec in self:
@@ -148,12 +155,14 @@ class ProjectProgress(models.Model):
     @api.depends('outsourcing_link_id', 'outsourcing_link_id.link_type')
     def _compute_type(self):
         for rec in self:
+            rec._check_can_write()
             rec.type = rec.outsourcing_link_id.link_type if rec.outsourcing_link_id else 'internal_production'
 
     # --- previous_progress_id ---
     @api.depends('accounting_closing_id', 'accounting_closing_id.previous_closing', 'outsourcing_link_id')
     def _compute_previous_progress_id(self):
         for rec in self:
+            rec._check_can_write()
             previous_closing = rec.accounting_closing_id.previous_closing
             if previous_closing:
                 rec.previous_progress_id = self.env['project.progress'].search([
@@ -166,6 +175,7 @@ class ProjectProgress(models.Model):
     # --- next_progress (non stocké, recalculé à chaque accès) ---
     def _compute_next_progress(self):
         for rec in self:
+            rec._check_can_write()
             rec.next_progress = self.env['project.progress'].search([('previous_progress_id', '=', rec.id)], limit=1)
 
     # --- target_project_cost ---
@@ -175,6 +185,7 @@ class ProjectProgress(models.Model):
     @api.depends('type', 'outsourcing_link_id')
     def _compute_target_project_cost(self):
         for rec in self:
+            rec._check_can_write()
             if rec.type == 'internal_production':
                 rec.target_project_cost = (rec.rel_project_id.company_part_cost_current or 0.0) + (rec.rel_project_id.company_part_cost_futur or 0.0)
             elif rec.outsourcing_link_id:
@@ -192,6 +203,7 @@ class ProjectProgress(models.Model):
     @api.depends('type', 'outsourcing_link_id')
     def _compute_target_project_revenue(self):
         for rec in self:
+            rec._check_can_write()
             if rec.type == 'internal_production':
                 rec.target_project_revenue = rec.rel_project_id.company_part_amount_current or 0.0
             elif rec.outsourcing_link_id:
@@ -208,32 +220,38 @@ class ProjectProgress(models.Model):
     @api.depends('target_project_revenue', 'target_project_cost')
     def _compute_target_project_margin(self):
         for rec in self:
+            rec._check_can_write()
             rec.target_project_margin = (rec.target_project_revenue or 0.0) - (rec.target_project_cost or 0.0)
 
     # --- target_project_margin_rate ---
     @api.depends('target_project_margin', 'target_project_revenue')
     def _compute_target_project_margin_rate(self):
         for rec in self:
+            rec._check_can_write()
             if rec.target_project_revenue:
                 rec.target_project_margin_rate = (rec.target_project_margin or 0.0) / rec.target_project_revenue
             else:
                 rec.target_project_margin_rate = 0.0
 
     # --- target_project_outsourcing_product_qty ---
-    @api.depends('outsourcing_link_id.order_sum_purchase_order_product_qty')
+    # Cette fonction est executée une seule fois à la création.
+    # Pas de dépendance sur outsourcing_link_id.order_sum_purchase_order_product_qty pour éviter l'écrasement
+    # des valeurs lorsque les données du BCF changent a posteriori.
     def _compute_target_project_outsourcing_product_qty(self):
-        #TODO : attention, cette zone va etre recalculée lorsque l'on change la qté sur le BCF => ça va bloquer margaux car ça sera interdit post validation
         for rec in self:
+            rec._check_can_write()
             rec.target_project_outsourcing_product_qty = rec.outsourcing_link_id.order_sum_purchase_order_product_qty if rec.outsourcing_link_id else 0.0
 
     # --- Quantités S/T ---
     @api.depends('progress_revenue_rate', 'target_project_outsourcing_product_qty')
     def _compute_outsourcing_product_qty(self):
         for rec in self:
+            rec._check_can_write()
             rec.outsourcing_product_qty = (rec.progress_revenue_rate or 0.0) * (rec.target_project_outsourcing_product_qty or 0.0)
 
     def _inverse_outsourcing_product_qty(self):
         for rec in self:
+            rec._check_can_write()
             target_qty = rec.target_project_outsourcing_product_qty or 0.0
             rec.progress_revenue_rate = (rec.outsourcing_product_qty / target_qty) if target_qty else 0.0
 
@@ -241,10 +259,12 @@ class ProjectProgress(models.Model):
     @api.depends('outsourcing_product_qty', 'previous_progress_id.outsourcing_product_qty')
     def _compute_qty_period(self):
         for rec in self:
+            rec._check_can_write()
             rec.outsourcing_product_qty_period = (rec.outsourcing_product_qty or 0.0) - (rec.previous_progress_id.outsourcing_product_qty or 0.0)
 
     def _inverse_qty_period(self):
         for rec in self:
+            rec._check_can_write()
             new_qty = (rec.previous_progress_id.outsourcing_product_qty or 0.0) + (rec.outsourcing_product_qty_period or 0.0)
             target_qty = rec.target_project_outsourcing_product_qty or 0.0
             rec.progress_revenue_rate = (new_qty / target_qty) if target_qty else 0.0
@@ -254,14 +274,17 @@ class ProjectProgress(models.Model):
                  'target_project_cost', 'progress_revenue_rate', 'outsourcing_product_qty', 'target_project_outsourcing_product_qty')
     def _compute_progress_cost_amount(self):
         for rec in self:
+            rec._check_can_write()
             if rec.type == 'internal_production':
                 rec.progress_cost_amount = -rec.rel_project_id.get_production_cost(
                     [('date', '<=', rec.rel_closing_date), ('category', '=', 'project_employee_validated')],
                     force_recompute_amount=False)[0]
             elif rec.outsourcing_link_id:
                 if rec.type == 'other':
-                    purchase_period_subtotal, purchase_period_total, purchase_period_paid, purchase_period_line_ids = rec.rel_project_id.compute_account_move_total_all_partners([('partner_id', '=', rec.outsourcing_link_id.partner_id.id), ('date', '<=', rec.rel_closing_date), ('parent_state', 'in', ['posted']), ('move_type', 'in', ['in_refund', 'in_invoice'])])
-                    rec.progress_cost_amount = -1 * purchase_period_subtotal
+                    if rec.rel_closing_date >= datetime.date(2026, 1, 1): 
+                        # Les données saisies manuellement sur les avancements d'initialisation de décembre 2026 ne doivent pas bouger
+                        purchase_period_subtotal, purchase_period_total, purchase_period_paid, purchase_period_line_ids = rec.rel_project_id.compute_account_move_total_all_partners([('partner_id', '=', rec.outsourcing_link_id.partner_id.id), ('date', '<=', rec.rel_closing_date), ('parent_state', 'in', ['posted']), ('move_type', 'in', ['in_refund', 'in_invoice'])])
+                        rec.progress_cost_amount = -1 * purchase_period_subtotal
                 else :
                     rec.progress_cost_amount = (rec.target_project_cost or 0.0) * (rec.progress_revenue_rate or 0.0)
             else:
@@ -271,6 +294,7 @@ class ProjectProgress(models.Model):
     @api.depends('type', 'progress_cost_amount', 'target_project_cost')
     def _compute_progress_revenue_rate(self):
         for rec in self:
+            rec._check_can_write()
             if rec.type in ['internal_production', 'other']:
                 rec.progress_revenue_rate = (rec.progress_cost_amount / rec.target_project_cost) if rec.target_project_cost else 0.0
 
@@ -281,22 +305,26 @@ class ProjectProgress(models.Model):
     @api.depends('target_project_revenue', 'progress_revenue_rate')
     def _compute_progress_revenue_amount(self):
         for rec in self:
+            rec._check_can_write()
             rec.progress_revenue_amount = (rec.target_project_revenue or 0.0) * (rec.progress_revenue_rate or 0.0)
 
     def _inverse_revenue(self):
         for rec in self:
+            rec._check_can_write()
             rec.progress_revenue_rate = (rec.progress_revenue_amount / rec.target_project_revenue) if rec.target_project_revenue else 0.0
 
     # --- progress_revenue_margin ---
     @api.depends('progress_revenue_amount', 'progress_cost_amount')
     def _compute_progress_revenue_margin(self):
         for rec in self:
+            rec._check_can_write()
             rec.progress_revenue_margin = (rec.progress_revenue_amount or 0.0) - (rec.progress_cost_amount or 0.0)    
     
     # --- progress_revenue_margin_rate ---
     @api.depends('progress_revenue_margin', 'progress_revenue_amount')
     def _compute_progress_revenue_margin_rate(self):
         for rec in self:
+            rec._check_can_write()
             if rec.progress_revenue_amount:
                 rec.progress_revenue_margin_rate = (rec.progress_revenue_margin or 0.0) / rec.progress_revenue_amount
             else:
@@ -306,33 +334,39 @@ class ProjectProgress(models.Model):
     @api.depends('progress_revenue_rate', 'rel_previous_progress_revenue_rate')
     def _compute_progress_revenue_rate_period(self):
         for rec in self:
+            rec._check_can_write()
             rec.progress_revenue_rate_period = (rec.progress_revenue_rate or 0.0) - (rec.rel_previous_progress_revenue_rate or 0.0)
 
     def _inverse_progress_revenue_rate_period(self):
         for rec in self:
+            rec._check_can_write()
             rec.progress_revenue_rate = (rec.rel_previous_progress_revenue_rate or 0.0) + (rec.progress_revenue_rate_period or 0.0)
 
     # --- progress_cost_amount_period ---
     @api.depends('progress_cost_amount', 'rel_previous_progress_cost_amount')
     def _compute_progress_cost_amount_period(self):
         for rec in self:
+            rec._check_can_write()
             rec.progress_cost_amount_period = (rec.progress_cost_amount or 0.0) - (rec.rel_previous_progress_cost_amount or 0.0)
 
     # --- progress_revenue_amount_period ---
     @api.depends('progress_revenue_amount', 'rel_previous_progress_revenue_amount')
     def _compute_progress_revenue_amount_period(self):
         for rec in self:
+            rec._check_can_write()
             rec.progress_revenue_amount_period = (rec.progress_revenue_amount or 0.0) - (rec.rel_previous_progress_revenue_amount or 0.0)
 
     @api.depends('progress_revenue_amount_period', 'progress_cost_amount_period')
     def _compute_progress_revenue_margin_period(self):
         for rec in self:
+            rec._check_can_write()
             rec.progress_revenue_margin_period = (rec.progress_revenue_amount_period or 0.0) - (rec.progress_cost_amount_period or 0.0)
 
     # --- progress_revenue_margin_rate_period ---
     @api.depends('progress_revenue_margin_period', 'progress_revenue_amount_period')
     def _compute_progress_revenue_margin_rate_period(self):
         for rec in self:
+            rec._check_can_write()
             if rec.progress_revenue_amount_period:
                 rec.progress_revenue_margin_rate_period = (rec.progress_revenue_margin_period or 0.0) / rec.progress_revenue_amount_period
             else:
@@ -342,6 +376,7 @@ class ProjectProgress(models.Model):
     @api.depends('type', 'rel_project_id', 'rel_closing_date')
     def _compute_future_staffing_days(self):
         for rec in self:
+            rec._check_can_write()
             if rec.type == 'internal_production' and rec.rel_project_id and rec.rel_closing_date:
                 # TODO : sur Napta, les périodes de forecast sont découpées à la semaine, sauf pour les fin de mois.
                 # Donc si le jour de clôture est en cours de semaine, alors il manquera des jours !
@@ -356,18 +391,21 @@ class ProjectProgress(models.Model):
     @api.depends('target_project_cost', 'target_project_outsourcing_product_qty')
     def _compute_price_unit(self):
         for rec in self:
+            rec._check_can_write()
             rec.price_unit = ((rec.target_project_cost or 0.0) / rec.target_project_outsourcing_product_qty) if rec.target_project_outsourcing_product_qty else 0.0
 
     # --- reselling_price_unit ---
     @api.depends('target_project_revenue', 'target_project_outsourcing_product_qty')
     def _compute_reselling_price_unit(self):
         for rec in self:
+            rec._check_can_write()
             rec.reselling_price_unit = ((rec.target_project_revenue or 0.0) / rec.target_project_outsourcing_product_qty) if rec.target_project_outsourcing_product_qty else 0.0
 
     # --- purchase_period_amount ---
     @api.depends('outsourcing_link_id', 'rel_project_id', 'rel_closing_date', 'accounting_closing_id.previous_closing')
     def _compute_purchase_period_amount(self):
         for rec in self:
+            rec._check_can_write()
             if not rec.outsourcing_link_id:
                 rec.purchase_period_amount = 0.0
                 continue
@@ -389,16 +427,19 @@ class ProjectProgress(models.Model):
     @api.depends('previous_progress_id.cca_balance')
     def _compute_cca_previous_balance(self):
         for rec in self:
+            rec._check_can_write()
             rec.cca_previous_balance = rec.previous_progress_id.cca_balance if rec.previous_progress_id else 0.0
 
     @api.depends('previous_progress_id.fnp_balance')
     def _compute_fnp_previous_balance(self):
         for rec in self:
+            rec._check_can_write()
             rec.fnp_previous_balance = rec.previous_progress_id.fnp_balance if rec.previous_progress_id else 0.0
 
     @api.depends('progress_cost_amount', 'rel_closing_date', 'outsourcing_link_id')
     def _compute_provisions_balances(self):
         for rec in self:
+            rec._check_can_write()
             if not rec.outsourcing_link_id:
                 rec.cca_balance = 0.0
                 rec.fnp_balance = 0.0
@@ -425,11 +466,13 @@ class ProjectProgress(models.Model):
     @api.depends('cca_balance', 'cca_previous_balance')
     def _compute_cca_period_amount(self):
         for rec in self:
+            rec._check_can_write()
             rec.cca_period_amount = rec.cca_balance - rec.cca_previous_balance
 
     @api.depends('fnp_balance', 'fnp_previous_balance')
     def _compute_fnp_period_amount(self):
         for rec in self:
+            rec._check_can_write()
             rec.fnp_period_amount = rec.fnp_balance - rec.fnp_previous_balance
 
     # ===================================================================

--- a/project_accounting/views/project_accounting_closing.xml
+++ b/project_accounting/views/project_accounting_closing.xml
@@ -81,6 +81,7 @@
                             <strong>Attention :</strong> le montant des achats de la période ne correspond pas à la somme des achats des lignes d'avancement.
                         </div>
                     </header>
+                    <sheet string="Project">
                     <group name="general" col="3">
                         <group string="Projet">
                             <field name="company_id" invisible="1"/>
@@ -205,6 +206,8 @@
                             <field name="rel_project_accounting_closing_ids"/>
                         </page>
                     </notebook>
+                </sheet>
+                <chatter/>
                 </form>
             </field>
         </record>


### PR DESCRIPTION
Refonte de l'architecture de calcul et securisation stricte de l'integrite des donnees historiques :

- project_accounting_closing.py :
  - Deplacement de la creation automatique des project.progress depuis la methode compute vers create (via create_project_progress). Cela evite les creations fantomes declenchees par le suivi dynamique des dependances de l'ORM lors de la modification des BCF.
  - Initialisation securisee du champ valuation_from_progress directement a la creation de l'enregistrement.
  - Extraction de la validation du write() vers _check_can_write.

- project_progress.py :
  - Injection systematique de la verification _check_can_write() en tete de toutes les methodes dependantes (@api.depends). Cette barriere empeche l'ORM de forcer la mise a jour des champs calcules sur des avancements deja valides.
  - Suppression de la dependance dynamique sur la quantite des BCF pour eviter les recalculs a posteriori.
  - Gel du recalcul des couts d'avancement pour les donnees d'initialisation (clotures antérieures au 1er janvier 2026).

- project_accounting_closing.xml :
  - Ajout des balises sheet et chatter pour standardiser la vue formulaire.