### PR TITLE
[FIX] project_accounting: securisation des onchange IHM face aux NewId

### DIFF
--- a/project_accounting/models/project.py
+++ b/project_accounting/models/project.py
@@ -1091,7 +1091,12 @@ class projectAccountProject(models.Model):
         #_logger.info('---- compute_margin_graph')
 
         for rec in self:
-            lines = self.env['account.analytic.line'].search([('project_id', '=', rec.id), '|', ('category', '=', 'project_employee_validated'), ('category', '=', 'project_forecast')], order="date asc, category")
+            from odoo import models
+            real_id = rec._origin.id if hasattr(rec, '_origin') and rec._origin else rec.id
+            if real_id and not isinstance(real_id, models.NewId):
+                lines = self.env['account.analytic.line'].search([('project_id', '=', real_id), '|', ('category', '=', 'project_employee_validated'), ('category', '=', 'project_forecast')], order="date asc, category")
+            else:
+                lines = self.env['account.analytic.line'].browse()
             real_lines_reversed = lines.filtered(lambda x: x.category == 'project_employee_validated').sorted(key=lambda r: r.date, reverse=True)
             if len(real_lines_reversed) > 0:
                 date_last_real = real_lines_reversed[0].date

--- a/project_accounting/models/project_progress.py
+++ b/project_accounting/models/project_progress.py
@@ -127,6 +127,8 @@ class ProjectProgress(models.Model):
         # On est obligé d'appeler cette fonction dans chaque fonction @depends car elles bypass write()
         #       Avant on ne contrôlait que dans write() et certaines valeur on été réécrites alors quel l'objet était déjà validé
         self.ensure_one()
+        if hasattr(models, 'NewId') and isinstance(self.id, models.NewId):
+            return
         if self.accounting_closing_id.is_validated:
             import traceback
             _logger.info("".join(traceback.format_stack()))
@@ -181,7 +183,11 @@ class ProjectProgress(models.Model):
     # --- next_progress (non stocké, recalculé à chaque accès) ---
     def _compute_next_progress(self):
         for rec in self:
-            rec.next_progress = self.env['project.progress'].search([('previous_progress_id', '=', rec.id)], limit=1)
+            real_id = rec._origin.id if hasattr(rec, '_origin') and rec._origin else rec.id
+            if real_id and not isinstance(real_id, models.NewId):
+                rec.next_progress = self.env['project.progress'].search([('previous_progress_id', '=', real_id)], limit=1)
+            else:
+                rec.next_progress = False
 
     # --- target_project_cost ---
     # Dépend uniquement de type et outsourcing_link_id (positionnés à la création).


### PR DESCRIPTION
- Correction d'un crash bloquant lors de la modification du statut d'un projet. L'IHM charge les enregistrements lies sous forme de brouillons virtuels (NewId), ce qui declenchait a tort la securite _check_can_write sur les avancements deja valides.
- Ajout d'une condition dans _check_can_write pour ignorer silencieusement les verifications lorsque l'enregistrement est de type NewId.
- Remplacement de rec.id par rec._origin.id dans les recherches SQL des methodes compute (compute_margin_graph et _compute_next_progress) afin d'eviter le warning Odoo (_condition_to_sql: ignored) et l'execution de requetes invalides lors des rafraichissements de l'interface.