### PR TITLE
[IMP/FIX] project_accounting: Édition des Autres Frais pour la Comptabilité et Correction des conflits ORM à la création

### DIFF
--- a/project_accounting/models/project_accounting_closing.py
+++ b/project_accounting/models/project_accounting_closing.py
@@ -111,15 +111,25 @@ class projectAccountingClosing(models.Model):
                             'accounting_closing_id': self.id,
                             'outsourcing_link_id': link.id,
                         }
+                        
+                        # Pour les avancements de type "outsourcing"
+                        # on veut initialiser qty_period / CA période / Cout de revuient période à 0€
+                        # pour obliger le DM à saisir la bonne valeur (qui reflète l'activité réelle sur S/T) 
+                        # Pour celà, on ne peut pas faire (à cause de l'ORM et des calculs dans tous les sens à la création):
+                        #          "new_progress_outsourcing.outsourcing_product_qty_period = 0.0"
+                        # Il faut chercher l'avancement précédent pour initialiser correctement le cumul.
+                        # Cela évite que les fonctions compute d'Odoo n'écrasent les valeurs à 0.0 à la création
+                        previous_progress = self.env['project.progress'].search([
+                            ('accounting_closing_id', '=', self.previous_closing.id),
+                            ('outsourcing_link_id', '=', link.id)
+                        ], limit=1) if self.previous_closing else False
+                        
+                        if previous_progress and link.link_type == 'outsourcing':
+                            # En reprenant le CA cumulé précédent, la variation de la période sera mathématiquement de 0.
+                            outsourcing_progress_dic['progress_revenue_amount'] = previous_progress.progress_revenue_amount
+
                         _logger.info("Creating project progress : %s " % str(outsourcing_progress_dic))
                         new_progress_outsourcing = self.env['project.progress'].create(outsourcing_progress_dic)
-                        # Après le create, previous_progress_id est résolu.
-                        # Pour le type 'autre', l'écriture à 0 déclenche _inverse_qty_period qui positionne
-                        # outsourcing_product_qty = previous.outsourcing_product_qty + 0
-                        # => l'avancement cumulé est repris de la période précédente.
-                        # Pour le type S/T, on laisse à 0 par défaut pour forcer la saisie du nouvel avancement.
-                        if link.link_type == 'outsourcing':
-                            new_progress_outsourcing.outsourcing_product_qty_period = 0.0
                 
                 # 2. For internal production
                 napta_id = getattr(self.project_id, 'napta_id', False)

--- a/project_accounting/models/project_progress.py
+++ b/project_accounting/models/project_progress.py
@@ -297,12 +297,13 @@ class ProjectProgress(models.Model):
     def _compute_progress_cost_amount(self):
         for rec in self:
             rec._check_can_write()
-            if rec.type == 'internal_production':
+            actual_type = rec.type or (rec.outsourcing_link_id.link_type if rec.outsourcing_link_id else 'internal_production')
+            if actual_type == 'internal_production':
                 rec.progress_cost_amount = -rec.rel_project_id.get_production_cost(
                     [('date', '<=', rec.rel_closing_date), ('category', '=', 'project_employee_validated')],
                     force_recompute_amount=False)[0]
             elif rec.outsourcing_link_id:
-                if rec.type == 'other':
+                if actual_type == 'other':
                     if rec.rel_closing_date >= datetime.date(2026, 1, 1): 
                         # Les données saisies manuellement sur les avancements d'initialisation de décembre 2026 ne doivent pas bouger
                         purchase_period_subtotal, purchase_period_total, purchase_period_paid, purchase_period_line_ids = rec.rel_project_id.compute_account_move_total_all_partners([('partner_id', '=', rec.outsourcing_link_id.partner_id.id), ('date', '<=', rec.rel_closing_date), ('parent_state', 'in', ['posted']), ('move_type', 'in', ['in_refund', 'in_invoice'])])
@@ -317,7 +318,8 @@ class ProjectProgress(models.Model):
     def _compute_progress_revenue_rate(self):
         for rec in self:
             rec._check_can_write()
-            if rec.type in ['internal_production', 'other']:
+            actual_type = rec.type or (rec.outsourcing_link_id.link_type if rec.outsourcing_link_id else 'internal_production')
+            if actual_type in ['internal_production', 'other']:
                 rec.progress_revenue_rate = (rec.progress_cost_amount / rec.target_project_cost) if rec.target_project_cost else 0.0
 
     def _inverse_progress_revenue_rate(self):

--- a/project_accounting/views/project_progress.xml
+++ b/project_accounting/views/project_progress.xml
@@ -64,7 +64,7 @@
         <field name="name">project.progress.form</field>
         <field name="model">project.progress</field>
         <field name="arch" type="xml">
-            <form string="Avancement" readonly="is_validated or type == 'other'">
+            <form string="Avancement" readonly="is_validated">
                 <header>
                     <field name="is_validated" invisible="1"/>
                     <button name="action_validate" string="✓ Valider" type="object" invisible="is_validated" class="btn-primary"/>
@@ -134,8 +134,10 @@
                                 invisible="type == 'internal_production'">
                             <field name="outsourcing_product_qty" readonly="1"/>
                             <field name="progress_cost_amount"/>
-                            <field name="progress_revenue_rate" widget="percentage" readonly="1"/>
-                            <field name="progress_revenue_amount" readonly="1"/>
+                            <field name="progress_revenue_rate" widget="percentage" readonly="1" groups="!account.group_account_user"/>
+                            <field name="progress_revenue_rate" widget="percentage" readonly="is_validated or type != 'other'" groups="account.group_account_user"/>
+                            <field name="progress_revenue_amount" readonly="1" groups="!account.group_account_user"/>
+                            <field name="progress_revenue_amount" readonly="is_validated or type != 'other'" groups="account.group_account_user"/>
                             <field name="progress_revenue_margin" decoration-danger="progress_revenue_margin &lt; 0"/>
                             <field name="progress_revenue_margin_rate" widget="percentage" decoration-danger="progress_revenue_margin_rate &lt; 0"/>
                         </group>

--- a/project_accounting/views/project_progress_multi_line.xml
+++ b/project_accounting/views/project_progress_multi_line.xml
@@ -5,7 +5,7 @@
         <field name="model">project.progress</field>
         <field name="type">list</field>
         <field name="arch" type="xml">
-            <list js_class="list_multi_line" editable="top" expand="1" open_form_view="1" limit="30" groups_limit="30" readonly="is_validated or type == 'other'">
+            <list js_class="list_multi_line" editable="top" expand="1" open_form_view="1" limit="30" groups_limit="30" readonly="is_validated">
                 <field name="company_id" invisible="1" groups="base.group_multi_company" options="{'no_create': True}" readonly="1"/>
                 <field name="currency_id" invisible="1"/>
                 <group col="4">
@@ -66,8 +66,10 @@
                             invisible="type == 'internal_production'">
                         <field name="outsourcing_product_qty" readonly="1"/>
                         <field name="progress_cost_amount"/>
-                        <field name="progress_revenue_rate" widget="percentage" readonly="1"/>
-                        <field name="progress_revenue_amount" readonly="1"/>
+                        <field name="progress_revenue_rate" widget="percentage" readonly="1" groups="!account.group_account_user"/>
+                        <field name="progress_revenue_rate" widget="percentage" readonly="is_validated or type != 'other'" groups="account.group_account_user"/>
+                        <field name="progress_revenue_amount" readonly="1" groups="!account.group_account_user"/>
+                        <field name="progress_revenue_amount" readonly="is_validated or type != 'other'" groups="account.group_account_user"/>
                         <field name="progress_revenue_margin" decoration-danger="progress_revenue_margin &lt; 0"/>
                         <field name="progress_revenue_margin_rate" widget="percentage" decoration-danger="progress_revenue_margin_rate &lt; 0"/>
                     </group>


### PR DESCRIPTION
## 🎯 Objectif de la PR
Cette PR stabilise le moteur de création des avancements de projet face aux instabilités de l'ORM Odoo, et débloque un besoin métier critique pour la Direction Financière concernant la saisie manuelle des "Autres frais".

## 🛠️ Problèmes résolus & Améliorations

### 1. Déblocage de la saisie manuelle pour le DAF (Autres frais)
- **Contexte :** Le DAF (Denis) avait besoin de modifier manuellement les montants des avancements de type `other`, notamment pour piloter les missions de prestations support d'Inditto et Ogires (`99TS002` et `99TS005`).
- **Solution :** Le verrou global `readonly="type == 'other'"` empêchait toute édition au niveau de la vue (liste et formulaire). Il a été levé.
- **Sécurité :** Mise en place d'un affichage conditionnel (via `groups="!account.group_account_user"`). Les utilisateurs standards voient toujours ces champs grisés, mais les membres du groupe "Comptabilité" ont désormais un accès en écriture sur le CA et le Taux cumulé (tant que l'avancement n'est pas verrouillé).

### 2. Correction des initialisations chaotiques de l'ORM (Race Conditions)
La création de nouveaux avancements en fin de mois via l'assistant de clôture déclenchait des "effets papillons" (conflits avec les méthodes `_inverse`) ou échouait à valoriser correctement les montants à cause de l'ordre d'évaluation de l'ORM. 

Deux correctifs majeurs ont été apportés pour restaurer l'intégrité de la donnée (les cumuls guident les périodes) :

- **Pour les Sous-traitances (`outsourcing`) :** 
  - Abandon de l'assignation forcée de la quantité période à 0.0, qui déclenchait la fonction inverse trop tôt et se faisait écraser par les `_compute` d'Odoo. 
  - On passe désormais explicitement la valeur du CA cumulé précédent (`progress_revenue_amount`) directement dans le dictionnaire de création de l'avancement. L'ORM valide mathématiquement une variation de période à zéro, sans aucun conflit ni besoin de forcer le cache.
  
- **Pour les factures fournisseurs (`other`) :**
  - L'ORM tentait de calculer le `progress_cost_amount` via des requêtes SQL *avant* même que le champ `type` de l'enregistrement en cours de création ne soit évalué. Résultat : un coût cumulé à 0.0, générant des variations de période négatives destructrices.
  - Mise en place d'un tri topologique dynamique avec la variable locale `actual_type` : si l'ORM n'a pas encore résolu le `type`, on le déduit du `outsourcing_link_id`. Cela garantit l'exécution immédiate des requêtes SQL de valorisation des factures **dès la création**, rendant obsolète l'usage de `force_refresh()`.
